### PR TITLE
Update aeson

### DIFF
--- a/aeson/row-types-aeson.cabal
+++ b/aeson/row-types-aeson.cabal
@@ -1,8 +1,8 @@
 Name:                row-types-aeson
-Version:             1.0.0.0
+Version:             1.1.0.0
 License:             MIT
 License-file:        LICENSE
-Author:              Daniel Winograd-Cort, Matthew Farkas-Dyck
+Author:              Daniel Winograd-Cort
 Maintainer:          dwincort@gmail.com
 homepage:            https://github.com/dwincort/row-types
 Build-Type:          Simple
@@ -22,7 +22,7 @@ extra-source-files:
 library
   default-language: Haskell2010
   Build-Depends:
-    aeson,
+    aeson >= 2,
     base >= 2 && < 6,
     row-types,
     text

--- a/aeson/src/Data/Row/Aeson.hs
+++ b/aeson/src/Data/Row/Aeson.hs
@@ -16,24 +16,24 @@ module Data.Row.Aeson () where
 
 import           Data.Aeson
 import           Data.Aeson.Encoding (pairStr)
+import qualified Data.Aeson.KeyMap as KeyMap
 import           Data.Aeson.Types    (typeMismatch)
 import           Data.List           (intercalate)
-import           Data.Text           (Text)
-import qualified Data.Text           as Text (pack)
+import           Data.String         (IsString (fromString))
 
 import           Data.Row
 import qualified Data.Row.Records  as Rec
 import qualified Data.Row.Variants as Var
 
 instance Forall r ToJSON => ToJSON (Rec r) where
-  toJSON = Object . Rec.eraseToHashMap @ToJSON toJSON
+  toJSON = Object . KeyMap.fromList . Rec.eraseWithLabels @ToJSON toJSON
 
   toEncoding =
     pairs . foldMap (uncurry pairStr) . Rec.eraseWithLabels @ToJSON toEncoding
 
 instance (AllUniqueLabels r, Forall r FromJSON) => FromJSON (Rec r) where
   parseJSON (Object o) = do
-    r <- Rec.fromLabelsA @FromJSON $ \ l -> do x <- o .: (show' l)
+    r <- Rec.fromLabelsA @FromJSON $ \ l -> do x <- o .: show' l
                                                x `seq` pure x
     r `seq` pure r
 
@@ -45,9 +45,9 @@ instance Forall r ToJSON => ToJSON (Var r) where
     where (l, foo) = Var.eraseWithLabels @ToJSON (\v l -> l .= v) v
 
 instance (AllUniqueLabels r, Forall r FromJSON) => FromJSON (Var r) where
-  parseJSON (Object o) = Var.fromLabels @FromJSON $ \ l -> o .: (show' l)
+  parseJSON (Object o) = Var.fromLabels @FromJSON $ \ l -> o .: show' l
   parseJSON v = typeMismatch msg v
     where msg = "VAR: {" ++ intercalate "," (labels @r @FromJSON) ++ "}"
 
-show' :: Show a => a -> Text
-show' = Text.pack . show
+show' :: (IsString s, Show a) => a -> s
+show' = fromString . show

--- a/barbies/row-types-barbies.cabal
+++ b/barbies/row-types-barbies.cabal
@@ -2,7 +2,7 @@ Name:                row-types-barbies
 Version:             1.0.0.0
 License:             MIT
 License-file:        LICENSE
-Author:              Daniel Winograd-Cort, Matthew Farkas-Dyck
+Author:              Daniel Winograd-Cort
 Maintainer:          dwincort@gmail.com
 homepage:            https://github.com/dwincort/row-types
 Build-Type:          Simple

--- a/barbies/src/Data/Row/Barbies.hs
+++ b/barbies/src/Data/Row/Barbies.hs
@@ -26,6 +26,7 @@ module Data.Row.Barbies () where
 import           Data.Functor.Compose
 import           Data.Functor.Identity
 import           Data.Functor.Product
+import           Data.Kind             (Type)
 import           Data.Row
 import           Data.Row.Dictionaries
 import qualified Data.Row.Records      as Rec
@@ -37,8 +38,8 @@ import qualified Barbies.Constraints as B
 -- | Barbies requires that the functor be the final argument of the type.  So,
 -- even though the real type is @Rec (Map f ρ)@, we must wrap it in a newtype
 -- wrapper so that 'f' is at the end.
-newtype BarbieRec (ρ :: Row *) (f :: * -> *) = BarbieRec { unBarbieRec :: Rec (Rec.Map f ρ) }
-newtype BarbieVar (ρ :: Row *) (f :: * -> *) = BarbieVar { unBarbieVar :: Var (Var.Map f ρ) }
+newtype BarbieRec (ρ :: Row Type) (f :: Type -> Type) = BarbieRec { unBarbieRec :: Rec (Rec.Map f ρ) }
+newtype BarbieVar (ρ :: Row Type) (f :: Type -> Type) = BarbieVar { unBarbieVar :: Var (Var.Map f ρ) }
 
 instance FreeForall r => FunctorB (BarbieRec r) where
   bmap f = BarbieRec . Rec.transform' @r f . unBarbieRec

--- a/row-types.cabal.3
+++ b/row-types.cabal.3
@@ -83,7 +83,7 @@ library row-types-aeson
   import: common-settings
   visibility: public
   Build-Depends:
-    aeson,
+    aeson >= 2,
     base >= 2 && < 6,
     row-types,
     text

--- a/src/Data/Row/Dictionaries.hs
+++ b/src/Data/Row/Dictionaries.hs
@@ -60,8 +60,8 @@ where
 import Data.Constraint
 import Data.Functor.Const
 import Data.Proxy
-import qualified Unsafe.Coerce as UNSAFE
 import GHC.TypeLits
+import qualified Unsafe.Coerce as UNSAFE
 
 import Data.Row.Internal
 
@@ -103,7 +103,7 @@ newtype ApSingleForall c a (fs :: Row (k -> k')) = ApSingleForall
 
 -- | This allows us to derive a @Forall (Map f r) ..@ from a @Forall r ..@.
 mapForall :: forall f ρ c. Forall ρ c :- Forall (Map f ρ) (IsA c f)
-mapForall = Sub $ unMapForall $ metamorph @_ @ρ @c @Const @Proxy @(MapForall c f) @Proxy Proxy empty uncons cons $ Proxy
+mapForall = Sub $ unMapForall $ metamorph @_ @ρ @c @Const @Proxy @(MapForall c f) @Proxy Proxy empty uncons cons Proxy
   where empty _ = MapForall Dict
         uncons _ _ = Const Proxy
         cons :: forall ℓ τ ρ. (KnownSymbol ℓ, c τ, FrontExtends ℓ τ ρ, AllUniqueLabels (Extend ℓ τ ρ))
@@ -116,7 +116,7 @@ mapForall = Sub $ unMapForall $ metamorph @_ @ρ @c @Const @Proxy @(MapForall c 
 
 -- | This allows us to derive a @Forall (ApSingle f r) ..@ from a @Forall f ..@.
 apSingleForall :: forall a fs c. Forall fs c :- Forall (ApSingle fs a) (ActsOn c a)
-apSingleForall = Sub $ unApSingleForall $ metamorph @_ @fs @c @Const @Proxy @(ApSingleForall c a) @Proxy Proxy empty uncons cons $ Proxy
+apSingleForall = Sub $ unApSingleForall $ metamorph @_ @fs @c @Const @Proxy @(ApSingleForall c a) @Proxy Proxy empty uncons cons Proxy
   where empty _ = ApSingleForall Dict
         uncons _ _ = Const Proxy
         cons :: forall ℓ τ ρ. (KnownSymbol ℓ, c τ, FrontExtends ℓ τ ρ, AllUniqueLabels (Extend ℓ τ ρ))
@@ -198,19 +198,19 @@ apSingleMinJoin = UNSAFE.unsafeCoerce $ Dict @Unconstrained
 
 -- | Two rows are subsets of a third if and only if their disjoint union is a
 -- subset of that third.
-subsetJoin :: forall r1 r2 s. Dict ((Subset r1 s, Subset r2 s) ≈ (Subset (r1 .+ r2) s))
+subsetJoin :: forall r1 r2 s. Dict ((Subset r1 s, Subset r2 s) ≈ Subset (r1 .+ r2) s)
 subsetJoin = UNSAFE.unsafeCoerce $ Dict @Unconstrained
 
 -- | If two rows are each subsets of a third, their join is a subset of the third
-subsetJoin' :: forall r1 r2 s. Dict ((Subset r1 s, Subset r2 s) ≈ (Subset (r1 .// r2) s))
+subsetJoin' :: forall r1 r2 s. Dict ((Subset r1 s, Subset r2 s) ≈ Subset (r1 .// r2) s)
 subsetJoin' = UNSAFE.unsafeCoerce $ Dict @Unconstrained
 
 -- | If a row is a subset of another, then its restriction is also a subset of the other
-subsetRestrict :: forall r s l. (Subset r s) :- (Subset (r .- l) s)
+subsetRestrict :: forall r s l. Subset r s :- Subset (r .- l) s
 subsetRestrict = Sub $ UNSAFE.unsafeCoerce $ Dict @Unconstrained
 
 -- | Subset is transitive
-subsetTrans :: forall r1 r2 r3. (Subset r1 r2, Subset r2 r3) :- (Subset r1 r3)
+subsetTrans :: forall r1 r2 r3. (Subset r1 r2, Subset r2 r3) :- Subset r1 r3
 subsetTrans = Sub $ UNSAFE.unsafeCoerce $ Dict @Unconstrained
 
 -- | Map distributes over Difference

--- a/src/Data/Row/Internal.hs
+++ b/src/Data/Row/Internal.hs
@@ -60,6 +60,7 @@ where
 import Data.Bifunctor (Bifunctor(..))
 import Data.Constraint
 import Data.Functor.Const
+import Data.Kind (Type)
 import Data.Proxy
 import Data.String (IsString (fromString))
 import Data.Text (Text)
@@ -209,7 +210,7 @@ type family (l :: Row k) .// (r :: Row k) where
 --------------------------------------------------------------------}
 -- | Alias for '.\'. It is a class rather than an alias, so that
 -- it can be partially applied.
-class Lacks (l :: Symbol) (r :: Row *)
+class Lacks (l :: Symbol) (r :: Row Type)
 instance (r .\ l) => Lacks l r
 
 
@@ -250,7 +251,7 @@ class Forall (r :: Row k) (c :: k -> Constraint) where
   -- For variants, @p = Either@, because there will either be a value or future types to
   -- explore.
   -- 'Const' can be useful when the types in the row are unnecessary.
-  metamorph :: forall (p :: * -> * -> *) (f :: Row k -> *) (g :: Row k -> *) (h :: k -> *). Bifunctor p
+  metamorph :: forall (p :: Type -> Type -> Type) (f :: Row k -> Type) (g :: Row k -> Type) (h :: k -> Type). Bifunctor p
             => Proxy (Proxy h, Proxy p)
             -> (f Empty -> g Empty)
                -- ^ The way to transform the empty element
@@ -279,8 +280,8 @@ instance (KnownSymbol ℓ, c τ, Forall ('R ρ) c, FrontExtends ℓ τ ('R ρ), 
 --   rows.
 class BiForall (r1 :: Row k1) (r2 :: Row k2) (c :: k1 -> k2 -> Constraint) where
   -- | A metamorphism is an anamorphism (an unfold) followed by a catamorphism (a fold).
-  biMetamorph :: forall (p :: * -> * -> *) (f :: Row k1 -> Row k2 -> *) (g :: Row k1 -> Row k2 -> *)
-                        (h :: k1 -> k2 -> *). Bifunctor p
+  biMetamorph :: forall (p :: Type -> Type -> Type) (f :: Row k1 -> Row k2 -> Type) (g :: Row k1 -> Row k2 -> Type)
+                        (h :: k1 -> k2 -> Type). Bifunctor p
               => Proxy (Proxy h, Proxy p)
               -> (f Empty Empty -> g Empty Empty)
               -> (forall ℓ τ1 τ2 ρ1 ρ2. (KnownSymbol ℓ, c τ1 τ2, HasType ℓ τ1 ρ1, HasType ℓ τ2 ρ2)
@@ -395,10 +396,10 @@ type family ApSingleR (fs :: [LT (a -> b)]) (x :: a) :: [LT b] where
 
 -- | Zips two rows together to create a Row of the pairs.
 --   The two rows must have the same set of labels.
-type family Zip (r1 :: Row *) (r2 :: Row *) where
+type family Zip (r1 :: Row Type) (r2 :: Row Type) where
   Zip (R r1) (R r2) = R (ZipR r1 r2)
 
-type family ZipR (r1 :: [LT *]) (r2 :: [LT *]) where
+type family ZipR (r1 :: [LT Type]) (r2 :: [LT Type]) where
   ZipR '[] '[] = '[]
   ZipR (l :-> t1 ': r1) (l :-> t2 ': r2) =
     l :-> (t1, t2) ': ZipR r1 r2

--- a/src/Data/Row/Switch.hs
+++ b/src/Data/Row/Switch.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}


### PR DESCRIPTION
Update to use the latest version of aeson in row-types-aeson.

Also fix some warnings and switch from `*` to `Type`.